### PR TITLE
Add modern styling and persistent dark mode

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,15 +1,18 @@
+'use client';
+
 import React from 'react';
-import { Box, Container, Typography } from '@mui/material';
+import { Box, Container, Typography, useTheme } from '@mui/material';
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const theme = useTheme();
   
   return (
     <Box
       component="footer"
       sx={{
-        backgroundColor: '#1E293B',
-        color: 'white',
+        backgroundColor: theme.palette.primary.dark,
+        color: theme.palette.getContrastText(theme.palette.primary.dark),
         py: 3,
         mt: 'auto',
       }}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React from 'react';
-import { AppBar, Toolbar, Container, Button, Box, useMediaQuery, IconButton, Drawer, List, ListItem } from '@mui/material';
-import { HomeRounded, InfoRounded, LinkedIn, GitHub, Menu as MenuIcon } from '@mui/icons-material';
+import { AppBar, Toolbar, Container, Button, Box, useMediaQuery, IconButton, Drawer, List, ListItem, useTheme } from '@mui/material';
+import { HomeRounded, InfoRounded, LinkedIn, GitHub, Menu as MenuIcon, Brightness4, Brightness7 } from '@mui/icons-material';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { usePathname } from 'next/navigation';
+import { ColorModeContext } from './ThemeRegistry/ThemeRegistry';
 
 const navItems = [
   { name: 'Home', href: '/', icon: <HomeRounded /> },
@@ -18,6 +19,8 @@ export default function Navbar() {
   const isMobile = useMediaQuery('(max-width:600px)');
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const pathname = usePathname();
+  const theme = useTheme();
+  const colorMode = React.useContext(ColorModeContext);
 
   const handleDrawerToggle = () => {
     setDrawerOpen(!drawerOpen);
@@ -53,7 +56,13 @@ export default function Navbar() {
   );
 
   return (
-    <AppBar position="static" sx={{ marginBottom: 2, backgroundColor: '#1E293B' }}>
+    <AppBar
+      position="static"
+      sx={{
+        marginBottom: 2,
+        background: 'linear-gradient(90deg, #0f172a, #1e293b)',
+      }}
+    >
       <Container maxWidth="xl">
         <Toolbar disableGutters sx={{ justifyContent: isMobile ? 'flex-end' : 'center' }}>
           {isMobile ? (
@@ -99,6 +108,9 @@ export default function Navbar() {
               <NavLinks />
             </Box>
           )}
+          <IconButton sx={{ ml: 1 }} onClick={colorMode.toggleColorMode} color="inherit">
+            {theme.palette.mode === 'dark' ? <Brightness7 /> : <Brightness4 />}
+          </IconButton>
         </Toolbar>
       </Container>
     </AppBar>

--- a/app/components/ThemeRegistry/ThemeRegistry.tsx
+++ b/app/components/ThemeRegistry/ThemeRegistry.tsx
@@ -1,18 +1,43 @@
 'use client';
 
 import * as React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider, createTheme, useTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import EmotionCache from './EmotionCache';
-import theme from './theme';
+import { getDesignTokens } from './theme';
+
+export const ColorModeContext = React.createContext({ toggleColorMode: () => {} });
 
 export default function ThemeRegistry({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = React.useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'light';
+    const stored = window.localStorage.getItem('color-mode');
+    if (stored === 'light' || stored === 'dark') return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+  const colorMode = React.useMemo(
+    () => ({
+      toggleColorMode: () => {
+        setMode(prev => {
+          const next = prev === 'light' ? 'dark' : 'light';
+          window.localStorage.setItem('color-mode', next);
+          return next;
+        });
+      },
+    }),
+    []
+  );
+
+  const theme = React.useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
+
   return (
-    <EmotionCache options={{ key: 'mui' }}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline enableColorScheme />
-        {children}
-      </ThemeProvider>
-    </EmotionCache>
+    <ColorModeContext.Provider value={colorMode}>
+      <EmotionCache options={{ key: 'mui' }}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline enableColorScheme />
+          {children}
+        </ThemeProvider>
+      </EmotionCache>
+    </ColorModeContext.Provider>
   );
 }

--- a/app/components/ThemeRegistry/theme.ts
+++ b/app/components/ThemeRegistry/theme.ts
@@ -1,33 +1,36 @@
 import { createTheme } from '@mui/material/styles';
-import { Roboto } from 'next/font/google';
+import type { PaletteMode, ThemeOptions } from '@mui/material';
+import { Inter } from 'next/font/google';
 
-const roboto = Roboto({
+const inter = Inter({
   weight: ['300', '400', '500', '700'],
   subsets: ['latin'],
   display: 'swap',
 });
 
-const theme = createTheme({
+export const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   typography: {
-    fontFamily: roboto.style.fontFamily,
+    fontFamily: inter.style.fontFamily,
   },
   palette: {
+    mode,
     primary: {
-      main: '#1976d2',
+      main: '#6366f1',
     },
     secondary: {
-      main: '#dc004e',
+      main: '#f43f5e',
     },
     background: {
-      default: '#f5f5f5',
+      default: mode === 'light' ? '#f8fafc' : '#0f172a',
+      paper: mode === 'light' ? '#ffffff' : '#1e293b',
     },
   },
   components: {
     MuiButton: {
       styleOverrides: {
         root: {
-          borderRadius: 8,
-          textTransform: 'none',
+          borderRadius: 12,
+          textTransform: 'none' as const,
         },
       },
     },
@@ -41,4 +44,3 @@ const theme = createTheme({
   },
 });
 
-export default theme;

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,4 +18,8 @@
 
 body {
   color: rgb(var(--foreground-rgb));
+  background: linear-gradient(to bottom right,
+      rgb(var(--background-start-rgb)),
+      rgb(var(--background-end-rgb)));
+  min-height: 100vh;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,23 +3,24 @@ import React from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import {
-	Box,
-	Container,
-	Typography,
-	Grid,
-	Card,
-	CardContent,
-	Button,
-	List,
-	ListItem,
-	ListItemText,
-	ListItemIcon,
-	Paper,
-	Divider,
-	Chip,
-	Avatar,
-	Alert,
+        Box,
+        Container,
+        Typography,
+        Grid,
+        Card,
+        CardContent,
+        Button,
+        List,
+        ListItem,
+        ListItemText,
+        ListItemIcon,
+        Paper,
+        Divider,
+        Chip,
+        Avatar,
+        Alert,
 } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import {
 	Download as DownloadIcon,
 	Code as CodeIcon,
@@ -52,8 +53,9 @@ const staggerContainer = {
 };
 
 export default function Home() {
-	const handleDownload = () => {
-		const resumeUrl = "/Guruprasad_Resume.pdf";
+        const theme = useTheme();
+        const handleDownload = () => {
+                const resumeUrl = "/Guruprasad_Resume.pdf";
 		const link = document.createElement("a");
 		link.href = resumeUrl;
 		link.download = "Guruprasad_Resume.pdf";
@@ -211,7 +213,7 @@ export default function Home() {
 								height: 200,
 								margin: "0 auto",
 								mb: 3,
-								border: "4px solid #1976d2",
+                                                                border: `4px solid ${theme.palette.primary.main}`,
 								boxShadow: "0 10px 25px rgba(0,0,0,0.2)",
 							}}
 						/>


### PR DESCRIPTION
## Summary
- persist color mode choice in ThemeRegistry
- switch theme to Inter font and vibrant color palette
- update navbar and footer styles
- add gradient background and modern accent on hero

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862cd0ecaa0833383451b0dce9745db